### PR TITLE
Refactor general MarkRenderer with MarkShader trait

### DIFF
--- a/vega-wgpu-renderer/src/lib.rs
+++ b/vega-wgpu-renderer/src/lib.rs
@@ -14,7 +14,6 @@ use winit::{
 };
 
 use crate::renderers::canvas::{Canvas, PngCanvas, WindowCanvas};
-use crate::renderers::symbol::SymbolMarkRenderer;
 use crate::scene::rect::RectInstance;
 use crate::scene::scene_graph::SceneGraph;
 use crate::scene::symbol::SymbolInstance;

--- a/vega-wgpu-renderer/src/renderers/mark.rs
+++ b/vega-wgpu-renderer/src/renderers/mark.rs
@@ -1,0 +1,189 @@
+use crate::renderers::canvas::CanvasUniform;
+use crate::renderers::vertex::Vertex;
+use crate::scene::rect::RectInstance;
+use wgpu::util::DeviceExt;
+use wgpu::{CommandBuffer, Device, TextureFormat, TextureView};
+
+pub trait MarkShader {
+    type Instance: bytemuck::Pod + bytemuck::Zeroable;
+    fn verts(&self) -> &[Vertex];
+    fn indices(&self) -> &[u16];
+    fn shader(&self) -> &str;
+    fn vertex_entry_point(&self) -> &str;
+    fn fragment_entry_point(&self) -> &str;
+    fn instance_desc(&self) -> wgpu::VertexBufferLayout<'static>;
+}
+
+pub struct MarkRenderer {
+    render_pipeline: wgpu::RenderPipeline,
+    vertex_buffer: wgpu::Buffer,
+    num_vertices: u32,
+    index_buffer: wgpu::Buffer,
+    num_indices: u32,
+    instance_buffer: wgpu::Buffer,
+    num_instances: u32,
+    uniform_buffer: wgpu::Buffer,
+    uniform: CanvasUniform,
+    uniform_bind_group: wgpu::BindGroup,
+}
+
+impl MarkRenderer {
+    pub fn new<T: bytemuck::Pod + bytemuck::Zeroable>(
+        device: &Device,
+        uniform: CanvasUniform,
+        texture_format: TextureFormat,
+        mark_shader: Box<dyn MarkShader<Instance = T>>,
+        instances: &[T],
+    ) -> Self {
+        // Uniforms
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Uniform Buffer"),
+            contents: bytemuck::cast_slice(&[uniform]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let uniform_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("chart_uniform_layout"),
+        });
+
+        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &uniform_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+            label: Some("uniform_bind_group"),
+        });
+
+        let _render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[&uniform_layout],
+                push_constant_ranges: &[],
+            });
+
+        // Shaders
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Shader"),
+            source: wgpu::ShaderSource::Wgsl(mark_shader.shader().into()),
+        });
+
+        let render_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[&uniform_layout],
+                push_constant_ranges: &[],
+            });
+
+        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Render Pipeline"),
+            layout: Some(&render_pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: mark_shader.vertex_entry_point(),
+                buffers: &[Vertex::desc(), mark_shader.instance_desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: mark_shader.fragment_entry_point(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: texture_format,
+                    blend: Some(wgpu::BlendState::REPLACE),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: Some(wgpu::Face::Back),
+                polygon_mode: wgpu::PolygonMode::Fill,
+                unclipped_depth: false,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview: None,
+        });
+
+        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Vertex Buffer"),
+            contents: bytemuck::cast_slice(mark_shader.verts()),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        let num_vertices = mark_shader.verts().len() as u32;
+
+        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Index Buffer"),
+            contents: bytemuck::cast_slice(mark_shader.indices()),
+            usage: wgpu::BufferUsages::INDEX,
+        });
+        let num_indices = mark_shader.indices().len() as u32;
+
+        let instance_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Instance Buffer"),
+            contents: bytemuck::cast_slice(instances),
+            usage: wgpu::BufferUsages::VERTEX,
+        });
+        let num_instances = instances.len() as u32;
+
+        Self {
+            render_pipeline,
+            vertex_buffer,
+            num_vertices,
+            index_buffer,
+            num_indices,
+            instance_buffer,
+            num_instances,
+            uniform_buffer,
+            uniform,
+            uniform_bind_group,
+        }
+    }
+
+    pub fn render(&self, device: &Device, texture_view: &TextureView) -> CommandBuffer {
+        let mut mark_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Mark Render Encoder"),
+        });
+
+        {
+            let mut render_pass = mark_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Mark Render Pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: texture_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                occlusion_query_set: None,
+                timestamp_writes: None,
+            });
+
+            render_pass.set_pipeline(&self.render_pipeline);
+            render_pass.set_bind_group(0, &self.uniform_bind_group, &[]);
+            render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+            render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
+            render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
+            render_pass.draw_indexed(0..self.num_indices, 0, 0..self.num_instances);
+        }
+
+        return mark_encoder.finish();
+    }
+}

--- a/vega-wgpu-renderer/src/renderers/mod.rs
+++ b/vega-wgpu-renderer/src/renderers/mod.rs
@@ -1,11 +1,5 @@
-use crate::renderers::rect::RectMarkRenderer;
-use crate::renderers::symbol::SymbolMarkRenderer;
 pub mod canvas;
+mod mark;
 pub mod rect;
 pub mod symbol;
 pub mod vertex;
-
-pub enum MarkRenderer {
-    Symbol(SymbolMarkRenderer),
-    Rect(RectMarkRenderer),
-}

--- a/vega-wgpu-renderer/src/renderers/rect.rs
+++ b/vega-wgpu-renderer/src/renderers/rect.rs
@@ -1,197 +1,89 @@
-use crate::renderers::canvas::CanvasUniform;
+use crate::renderers::mark::MarkShader;
 use crate::renderers::vertex::Vertex;
 use crate::scene::rect::RectInstance;
-use crate::specs::rect::RectItemSpec;
-use crate::specs::symbol::SymbolItemSpec;
-use wgpu::util::DeviceExt;
-use wgpu::{CommandBuffer, Device, TextureFormat, TextureView};
 
-const RECT_VERTICES: &[Vertex] = &[
-    Vertex {
-        position: [0.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, 0.0, 0.0],
-    },
-    Vertex {
-        position: [1.0, 1.0, 0.0],
-    },
-    Vertex {
-        position: [0.0, 1.0, 0.0],
-    },
-];
-
-const RECT_INDICES: &[u16] = &[0, 1, 2, 0, 2, 3];
-
-pub struct RectMarkRenderer {
-    render_pipeline: wgpu::RenderPipeline,
-    vertex_buffer: wgpu::Buffer,
-    num_vertices: u32,
-    index_buffer: wgpu::Buffer,
-    num_indices: u32,
-    instance_buffer: wgpu::Buffer,
-    num_instances: u32,
-    uniform_buffer: wgpu::Buffer,
-    uniform: CanvasUniform,
-    uniform_bind_group: wgpu::BindGroup,
+pub struct RectShader {
+    verts: Vec<Vertex>,
+    indices: Vec<u16>,
+    shader: String,
+    vertex_entry_point: String,
+    fragment_entry_point: String,
 }
 
-impl RectMarkRenderer {
-    pub fn new(
-        device: &Device,
-        uniform: CanvasUniform,
-        texture_format: TextureFormat,
-        instances: &[RectInstance],
-    ) -> Self {
-        // Uniforms
-        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Uniform Buffer"),
-            contents: bytemuck::cast_slice(&[uniform]),
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-        });
-
-        let uniform_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-            label: Some("chart_uniform_layout"),
-        });
-
-        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &uniform_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-            label: Some("uniform_bind_group"),
-        });
-
-        let _render_pipeline_layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("Render Pipeline Layout"),
-                bind_group_layouts: &[&uniform_layout],
-                push_constant_ranges: &[],
-            });
-
-        // Shaders
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("rect.wgsl").into()),
-        });
-
-        let render_pipeline_layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("Render Pipeline Layout"),
-                bind_group_layouts: &[&uniform_layout],
-                push_constant_ranges: &[],
-            });
-
-        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Render Pipeline"),
-            layout: Some(&render_pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: "vs_main",
-                buffers: &[Vertex::desc(), RectInstance::desc()],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: "fs_main",
-                targets: &[Some(wgpu::ColorTargetState {
-                    format: texture_format,
-                    blend: Some(wgpu::BlendState::REPLACE),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
-                front_face: wgpu::FrontFace::Ccw,
-                cull_mode: Some(wgpu::Face::Back),
-                polygon_mode: wgpu::PolygonMode::Fill,
-                unclipped_depth: false,
-                conservative: false,
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState {
-                count: 1,
-                mask: !0,
-                alpha_to_coverage_enabled: false,
-            },
-            multiview: None,
-        });
-
-        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Vertex Buffer"),
-            contents: bytemuck::cast_slice(RECT_VERTICES),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        let num_vertices = RECT_VERTICES.len() as u32;
-
-        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Index Buffer"),
-            contents: bytemuck::cast_slice(RECT_INDICES),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        let num_indices = RECT_INDICES.len() as u32;
-
-        let instance_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Instance Buffer"),
-            contents: bytemuck::cast_slice(instances),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        let num_instances = instances.len() as u32;
-
+impl RectShader {
+    pub fn new() -> Self {
         Self {
-            render_pipeline,
-            vertex_buffer,
-            num_vertices,
-            index_buffer,
-            num_indices,
-            instance_buffer,
-            num_instances,
-            uniform_buffer,
-            uniform,
-            uniform_bind_group,
+            verts: vec![
+                Vertex {
+                    position: [0.0, 0.0, 0.0],
+                },
+                Vertex {
+                    position: [1.0, 0.0, 0.0],
+                },
+                Vertex {
+                    position: [1.0, 1.0, 0.0],
+                },
+                Vertex {
+                    position: [0.0, 1.0, 0.0],
+                },
+            ],
+            indices: vec![0, 1, 2, 0, 2, 3],
+            shader: include_str!("rect.wgsl").to_string(),
+            vertex_entry_point: "vs_main".to_string(),
+            fragment_entry_point: "fs_main".to_string(),
         }
     }
+}
 
-    pub fn render(&self, device: &Device, texture_view: &TextureView) -> CommandBuffer {
-        let mut mark_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("Mark Render Encoder"),
-        });
+impl MarkShader for RectShader {
+    type Instance = RectInstance;
 
-        {
-            let mut render_pass = mark_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("Mark Render Pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: texture_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                occlusion_query_set: None,
-                timestamp_writes: None,
-            });
+    fn verts(&self) -> &[Vertex] {
+        self.verts.as_slice()
+    }
 
-            render_pass.set_pipeline(&self.render_pipeline);
-            render_pass.set_bind_group(0, &self.uniform_bind_group, &[]);
-            render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-            render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
-            render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-            render_pass.draw_indexed(0..self.num_indices, 0, 0..self.num_instances);
+    fn indices(&self) -> &[u16] {
+        self.indices.as_slice()
+    }
+
+    fn shader(&self) -> &str {
+        self.shader.as_str()
+    }
+
+    fn vertex_entry_point(&self) -> &str {
+        self.vertex_entry_point.as_str()
+    }
+
+    fn fragment_entry_point(&self) -> &str {
+        self.fragment_entry_point.as_str()
+    }
+
+    fn instance_desc(&self) -> wgpu::VertexBufferLayout<'static> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<RectInstance>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 1,
+                    format: wgpu::VertexFormat::Float32x2,
+                },
+                wgpu::VertexAttribute {
+                    offset: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    shader_location: 2,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
+                wgpu::VertexAttribute {
+                    offset: std::mem::size_of::<[f32; 5]>() as wgpu::BufferAddress,
+                    shader_location: 3,
+                    format: wgpu::VertexFormat::Float32,
+                },
+                wgpu::VertexAttribute {
+                    offset: std::mem::size_of::<[f32; 6]>() as wgpu::BufferAddress,
+                    shader_location: 4,
+                    format: wgpu::VertexFormat::Float32,
+                },
+            ],
         }
-
-        return mark_encoder.finish();
     }
 }

--- a/vega-wgpu-renderer/src/renderers/symbol.rs
+++ b/vega-wgpu-renderer/src/renderers/symbol.rs
@@ -1,202 +1,87 @@
-use crate::renderers::canvas::CanvasUniform;
+use crate::renderers::mark::MarkShader;
 use crate::renderers::vertex::Vertex;
 use crate::scene::symbol::SymbolInstance;
-use crate::specs::symbol::SymbolItemSpec;
-use wgpu::util::DeviceExt;
-use wgpu::{CommandBuffer, Device, Surface, TextureFormat, TextureView};
 
-fn symbol_verts() -> Vec<Vertex> {
-    let tan30: f32 = (30.0 * std::f32::consts::PI / 180.0).tan();
-    let radius: f32 = (1.0 / (2.0 * tan30)).sqrt();
-
-    vec![
-        Vertex {
-            position: [0.0, -radius, 0.0],
-        },
-        Vertex {
-            position: [radius, 0.0, 0.0],
-        },
-        Vertex {
-            position: [0.0, radius, 0.0],
-        },
-        Vertex {
-            position: [-radius, 0.0, 0.0],
-        },
-    ]
+pub struct SymbolShader {
+    verts: Vec<Vertex>,
+    indices: Vec<u16>,
+    shader: String,
+    vertex_entry_point: String,
+    fragment_entry_point: String,
 }
 
-const SYMBOL_INDICES: &[u16] = &[0, 1, 2, 0, 2, 3];
-
-pub struct SymbolMarkRenderer {
-    render_pipeline: wgpu::RenderPipeline,
-    vertex_buffer: wgpu::Buffer,
-    num_vertices: u32,
-    index_buffer: wgpu::Buffer,
-    num_indices: u32,
-    instance_buffer: wgpu::Buffer,
-    num_instances: u32,
-    uniform_buffer: wgpu::Buffer,
-    uniform: CanvasUniform,
-    uniform_bind_group: wgpu::BindGroup,
-}
-
-impl SymbolMarkRenderer {
-    pub fn new(
-        device: &Device,
-        uniform: CanvasUniform,
-        texture_format: TextureFormat,
-        instances: &[SymbolInstance],
-    ) -> Self {
-        // Uniforms
-        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Uniform Buffer"),
-            contents: bytemuck::cast_slice(&[uniform]),
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-        });
-
-        let uniform_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            entries: &[wgpu::BindGroupLayoutEntry {
-                binding: 0,
-                visibility: wgpu::ShaderStages::VERTEX,
-                ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
-                    has_dynamic_offset: false,
-                    min_binding_size: None,
-                },
-                count: None,
-            }],
-            label: Some("chart_uniform_layout"),
-        });
-
-        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &uniform_layout,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: uniform_buffer.as_entire_binding(),
-            }],
-            label: Some("uniform_bind_group"),
-        });
-
-        let _render_pipeline_layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("Render Pipeline Layout"),
-                bind_group_layouts: &[&uniform_layout],
-                push_constant_ranges: &[],
-            });
-
-        // Shaders
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("Shader"),
-            source: wgpu::ShaderSource::Wgsl(include_str!("symbol.wgsl").into()),
-        });
-
-        let render_pipeline_layout =
-            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("Render Pipeline Layout"),
-                bind_group_layouts: &[&uniform_layout],
-                push_constant_ranges: &[],
-            });
-
-        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("Render Pipeline"),
-            layout: Some(&render_pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: "vs_main",
-                buffers: &[Vertex::desc(), SymbolInstance::desc()],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: "fs_main",
-                targets: &[Some(wgpu::ColorTargetState {
-                    format: texture_format,
-                    blend: Some(wgpu::BlendState::REPLACE),
-                    write_mask: wgpu::ColorWrites::ALL,
-                })],
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
-                front_face: wgpu::FrontFace::Ccw,
-                cull_mode: Some(wgpu::Face::Back),
-                polygon_mode: wgpu::PolygonMode::Fill,
-                unclipped_depth: false,
-                conservative: false,
-            },
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState {
-                count: 1,
-                mask: !0,
-                alpha_to_coverage_enabled: false,
-            },
-            multiview: None,
-        });
-
-        let verts = symbol_verts();
-        let vertex_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Vertex Buffer"),
-            contents: bytemuck::cast_slice(verts.as_slice()),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        let num_vertices = verts.len() as u32;
-
-        let index_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Index Buffer"),
-            contents: bytemuck::cast_slice(SYMBOL_INDICES),
-            usage: wgpu::BufferUsages::INDEX,
-        });
-        let num_indices = SYMBOL_INDICES.len() as u32;
-
-        let instance_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("Instance Buffer"),
-            contents: bytemuck::cast_slice(instances),
-            usage: wgpu::BufferUsages::VERTEX,
-        });
-        let num_instances = instances.len() as u32;
+impl SymbolShader {
+    pub fn new() -> Self {
+        let tan30: f32 = (30.0 * std::f32::consts::PI / 180.0).tan();
+        let radius: f32 = (1.0 / (2.0 * tan30)).sqrt();
 
         Self {
-            render_pipeline,
-            vertex_buffer,
-            num_vertices,
-            index_buffer,
-            num_indices,
-            instance_buffer,
-            num_instances,
-            uniform_buffer,
-            uniform,
-            uniform_bind_group,
+            verts: vec![
+                Vertex {
+                    position: [0.0, -radius, 0.0],
+                },
+                Vertex {
+                    position: [radius, 0.0, 0.0],
+                },
+                Vertex {
+                    position: [0.0, radius, 0.0],
+                },
+                Vertex {
+                    position: [-radius, 0.0, 0.0],
+                },
+            ],
+            indices: vec![0, 1, 2, 0, 2, 3],
+            shader: include_str!("symbol.wgsl").to_string(),
+            vertex_entry_point: "vs_main".to_string(),
+            fragment_entry_point: "fs_main".to_string(),
         }
     }
+}
 
-    pub fn render(&self, device: &Device, texture_view: &TextureView) -> CommandBuffer {
-        let mut mark_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("Mark Render Encoder"),
-        });
+impl MarkShader for SymbolShader {
+    type Instance = SymbolInstance;
 
-        {
-            let mut render_pass = mark_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                label: Some("Mark Render Pass"),
-                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                    view: texture_view,
-                    resolve_target: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                occlusion_query_set: None,
-                timestamp_writes: None,
-            });
+    fn verts(&self) -> &[Vertex] {
+        self.verts.as_slice()
+    }
 
-            render_pass.set_pipeline(&self.render_pipeline);
-            render_pass.set_bind_group(0, &self.uniform_bind_group, &[]);
-            render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
-            render_pass.set_vertex_buffer(1, self.instance_buffer.slice(..));
-            render_pass.set_index_buffer(self.index_buffer.slice(..), wgpu::IndexFormat::Uint16);
-            render_pass.draw_indexed(0..self.num_indices, 0, 0..self.num_instances);
+    fn indices(&self) -> &[u16] {
+        self.indices.as_slice()
+    }
+
+    fn shader(&self) -> &str {
+        self.shader.as_str()
+    }
+
+    fn vertex_entry_point(&self) -> &str {
+        self.vertex_entry_point.as_str()
+    }
+
+    fn fragment_entry_point(&self) -> &str {
+        self.fragment_entry_point.as_str()
+    }
+
+    fn instance_desc(&self) -> wgpu::VertexBufferLayout<'static> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<SymbolInstance>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 1,
+                    format: wgpu::VertexFormat::Float32x2,
+                },
+                wgpu::VertexAttribute {
+                    offset: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
+                    shader_location: 2,
+                    format: wgpu::VertexFormat::Float32x3,
+                },
+                wgpu::VertexAttribute {
+                    offset: std::mem::size_of::<[f32; 5]>() as wgpu::BufferAddress,
+                    shader_location: 3,
+                    format: wgpu::VertexFormat::Float32,
+                },
+            ],
         }
-
-        return mark_encoder.finish();
     }
 }

--- a/vega-wgpu-renderer/src/scene/rect.rs
+++ b/vega-wgpu-renderer/src/scene/rect.rs
@@ -29,35 +29,6 @@ pub struct RectInstance {
 }
 
 impl RectInstance {
-    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
-        wgpu::VertexBufferLayout {
-            array_stride: std::mem::size_of::<RectInstance>() as wgpu::BufferAddress,
-            step_mode: wgpu::VertexStepMode::Instance,
-            attributes: &[
-                wgpu::VertexAttribute {
-                    offset: 0,
-                    shader_location: 1,
-                    format: wgpu::VertexFormat::Float32x2,
-                },
-                wgpu::VertexAttribute {
-                    offset: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
-                    shader_location: 2,
-                    format: wgpu::VertexFormat::Float32x3,
-                },
-                wgpu::VertexAttribute {
-                    offset: std::mem::size_of::<[f32; 5]>() as wgpu::BufferAddress,
-                    shader_location: 3,
-                    format: wgpu::VertexFormat::Float32,
-                },
-                wgpu::VertexAttribute {
-                    offset: std::mem::size_of::<[f32; 6]>() as wgpu::BufferAddress,
-                    shader_location: 4,
-                    format: wgpu::VertexFormat::Float32,
-                },
-            ],
-        }
-    }
-
     pub fn from_spec(item_spec: &RectItemSpec) -> Result<Self, VegaWgpuError> {
         // TODO: x2, y2
         let color = if let Some(fill) = &item_spec.fill {

--- a/vega-wgpu-renderer/src/scene/symbol.rs
+++ b/vega-wgpu-renderer/src/scene/symbol.rs
@@ -28,30 +28,6 @@ pub struct SymbolInstance {
 }
 
 impl SymbolInstance {
-    pub fn desc() -> wgpu::VertexBufferLayout<'static> {
-        wgpu::VertexBufferLayout {
-            array_stride: std::mem::size_of::<SymbolInstance>() as wgpu::BufferAddress,
-            step_mode: wgpu::VertexStepMode::Instance,
-            attributes: &[
-                wgpu::VertexAttribute {
-                    offset: 0,
-                    shader_location: 1,
-                    format: wgpu::VertexFormat::Float32x2,
-                },
-                wgpu::VertexAttribute {
-                    offset: std::mem::size_of::<[f32; 2]>() as wgpu::BufferAddress,
-                    shader_location: 2,
-                    format: wgpu::VertexFormat::Float32x3,
-                },
-                wgpu::VertexAttribute {
-                    offset: std::mem::size_of::<[f32; 5]>() as wgpu::BufferAddress,
-                    shader_location: 3,
-                    format: wgpu::VertexFormat::Float32,
-                },
-            ],
-        }
-    }
-
     pub fn from_spec(item_spec: &SymbolItemSpec) -> Result<Self, VegaWgpuError> {
         let color = if let Some(fill) = &item_spec.fill {
             let c = csscolorparser::parse(fill)?;


### PR DESCRIPTION
Refactor to reduce code duplication across the Symbol and Rect mark renderers.

Replaces the RectRenderer and SymbolRenderer structs with a general purpose MarkRenderer struct. The constructor inputs an instance of the new MarkShader trait which encapsulates the vertex and shader data for the mark.