### PR TITLE
Add MSAA

### DIFF
--- a/vega-wgpu-renderer/src/renderers/mark.rs
+++ b/vega-wgpu-renderer/src/renderers/mark.rs
@@ -32,6 +32,7 @@ impl MarkRenderer {
         device: &Device,
         uniform: CanvasUniform,
         texture_format: TextureFormat,
+        sample_count: u32,
         mark_shader: Box<dyn MarkShader<Instance = T>>,
         instances: &[T],
     ) -> Self {
@@ -113,7 +114,7 @@ impl MarkRenderer {
             },
             depth_stencil: None,
             multisample: wgpu::MultisampleState {
-                count: 1,
+                count: sample_count,
                 mask: !0,
                 alpha_to_coverage_enabled: false,
             },
@@ -155,7 +156,12 @@ impl MarkRenderer {
         }
     }
 
-    pub fn render(&self, device: &Device, texture_view: &TextureView) -> CommandBuffer {
+    pub fn render(
+        &self,
+        device: &Device,
+        texture_view: &TextureView,
+        resolve_target: Option<&TextureView>,
+    ) -> CommandBuffer {
         let mut mark_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("Mark Render Encoder"),
         });
@@ -165,7 +171,7 @@ impl MarkRenderer {
                 label: Some("Mark Render Pass"),
                 color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                     view: texture_view,
-                    resolve_target: None,
+                    resolve_target,
                     ops: wgpu::Operations {
                         load: wgpu::LoadOp::Load,
                         store: wgpu::StoreOp::Store,

--- a/vega-wgpu-renderer/src/renderers/symbol.rs
+++ b/vega-wgpu-renderer/src/renderers/symbol.rs
@@ -112,8 +112,7 @@ impl SymbolShader {
                 }
             }
             SymbolShape::Diamond => {
-                let ry: f32 = (1.0 / (2.0 * tan30)).sqrt();
-                let r: f32 = ry * tan30;
+                let r: f32 = 0.5;
                 Self {
                     verts: vec![
                         Vertex {

--- a/vega-wgpu-renderer/tests/test_image_baselines.rs
+++ b/vega-wgpu-renderer/tests/test_image_baselines.rs
@@ -17,18 +17,18 @@ mod test_image_baselines {
         tolerance,
         case("rect", "stacked_bar", 0.001),
         case("rect", "heatmap", 0.006),
-        case("symbol", "binned_scatter_diamonds", 0.006),
-        case("symbol", "binned_scatter_square", 0.012),
-        case("symbol", "binned_scatter_triangle-down", 0.007),
-        case("symbol", "binned_scatter_triangle-up", 0.007),
-        case("symbol", "binned_scatter_triangle-left", 0.009),
-        case("symbol", "binned_scatter_triangle-right", 0.009),
-        case("symbol", "binned_scatter_triangle", 0.009),
-        case("symbol", "binned_scatter_wedge", 0.009),
-        case("symbol", "binned_scatter_arrow", 0.009),
-        case("symbol", "binned_scatter_cross", 0.01),
-        case("symbol", "binned_scatter_circle", 0.0004),
-        case("rule", "wide_rule_axes", 0.0004)
+        case("symbol", "binned_scatter_diamonds", 0.001),
+        case("symbol", "binned_scatter_square", 0.001),
+        case("symbol", "binned_scatter_triangle-down", 0.001),
+        case("symbol", "binned_scatter_triangle-up", 0.001),
+        case("symbol", "binned_scatter_triangle-left", 0.001),
+        case("symbol", "binned_scatter_triangle-right", 0.001),
+        case("symbol", "binned_scatter_triangle", 0.001),
+        case("symbol", "binned_scatter_wedge", 0.001),
+        case("symbol", "binned_scatter_arrow", 0.001),
+        case("symbol", "binned_scatter_cross", 0.001),
+        case("symbol", "binned_scatter_circle", 0.001),
+        case("rule", "wide_rule_axes", 0.0001)
     )]
     fn test_image_baseline(category: &str, spec_name: &str, tolerance: f64) {
         let specs_dir = format!("{}/tests/specs/{category}", env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
Add's MSAA anti-aliasing following the wgpu example at https://github.com/gfx-rs/wgpu/tree/46757372cc02d6608124502104a0c225e1744fd7/examples/src/msaa_line.

This improves the match with the baseline resvg rendered PNG images and so I also lowered the test tolerance.