### PR TITLE
Fix wasm build and examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5279,6 +5279,7 @@ dependencies = [
 name = "sg2d-vega"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "csscolorparser",
  "image",
  "lyon_extra",

--- a/examples/scatter-panning/Cargo.lock
+++ b/examples/scatter-panning/Cargo.lock
@@ -2193,11 +2193,11 @@ dependencies = [
 name = "sg2d-vega"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "csscolorparser",
  "image",
  "lyon_extra",
  "lyon_path",
- "reqwest",
  "serde",
  "serde_json",
  "sg2d",

--- a/examples/scatter-panning/Cargo.lock
+++ b/examples/scatter-panning/Cargo.lock
@@ -616,9 +616,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fontconfig-parser"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4"
+checksum = "6a595cb550439a117696039dfc69830492058211b771a2a165379f2a1a53d84d"
 dependencies = [
  "roxmltree",
 ]
@@ -1995,12 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
-dependencies = [
- "xmlparser",
-]
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rustc-demangle"
@@ -2625,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f91c8b21fbbaa18853c3d0801c78f4fc94cdb976699bb03e832e75f7fd22f0"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
 name = "unicode-script"
@@ -3284,12 +3281,6 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yazi"

--- a/examples/wgpu-winit/Cargo.lock
+++ b/examples/wgpu-winit/Cargo.lock
@@ -384,27 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-text"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75acbfb314aeb4f5210d379af45ed1ec2c98c7f1790bf57b8a4c562ac0c51b71"
-dependencies = [
- "fontdb",
- "libm",
- "log",
- "rangemap",
- "rustc-hash",
- "rustybuzz",
- "self_cell",
- "swash",
- "sys-locale",
- "unicode-bidi",
- "unicode-linebreak",
- "unicode-script",
- "unicode-segmentation",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,29 +594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fontconfig-parser"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4"
-dependencies = [
- "roxmltree",
-]
-
-[[package]]
-name = "fontdb"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020e203f177c0fb250fb19455a252e838d2bbbce1f80f25ecc42402aafa8cd38"
-dependencies = [
- "fontconfig-parser",
- "log",
- "memmap2 0.8.0",
- "slotmap",
- "tinyvec",
- "ttf-parser 0.19.2",
-]
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,17 +762,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
 dependencies = [
  "gl_generator",
-]
-
-[[package]]
-name = "glyphon"
-version = "0.3.0"
-source = "git+https://github.com/jonmmease/glyphon.git?rev=c468f5dacd4130b27a29b098c4de3f4d5c146209#c468f5dacd4130b27a29b098c4de3f4d5c146209"
-dependencies = [
- "cosmic-text",
- "etagere",
- "lru",
- "wgpu",
 ]
 
 [[package]]
@@ -1224,15 +1169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "lru"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
 name = "lyon"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,15 +1251,6 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
 dependencies = [
  "libc",
 ]
@@ -1662,7 +1589,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
 dependencies = [
- "ttf-parser 0.20.0",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1850,12 +1777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
-name = "rangemap"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977b1e897f9d764566891689e642653e5ed90c6895106acd005eb4c1d0203991"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,15 +1894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "roxmltree"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
-dependencies = [
- "xmlparser",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2004,23 +1916,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustybuzz"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee8fe2a8461a0854a37101fe7a1b13998d0cfa987e43248e81d2a5f4570f6fa"
-dependencies = [
- "bitflags 1.3.2",
- "bytemuck",
- "libm",
- "smallvec",
- "ttf-parser 0.20.0",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
 ]
 
 [[package]]
@@ -2058,7 +1953,7 @@ checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
 dependencies = [
  "ab_glyph",
  "log",
- "memmap2 0.5.10",
+ "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
 ]
@@ -2085,12 +1980,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "self_cell"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bf37232d3bb9a2c4e641ca2a11d83b5062066f88df7fed36c28772046d65ba"
 
 [[package]]
 name = "serde"
@@ -2172,7 +2061,6 @@ dependencies = [
  "env_logger",
  "etagere",
  "futures-intrusive",
- "glyphon",
  "image",
  "itertools",
  "log",
@@ -2231,7 +2119,7 @@ dependencies = [
  "dlib",
  "lazy_static",
  "log",
- "memmap2 0.5.10",
+ "memmap2",
  "nix 0.24.3",
  "pkg-config",
  "wayland-client",
@@ -2287,16 +2175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 
 [[package]]
-name = "swash"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7c73c813353c347272919aa1af2885068b05e625e5532b43049e4f641ae77f"
-dependencies = [
- "yazi",
- "zeno",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,15 +2194,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "sys-locale"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801cf239ecd6ccd71f03d270d67dd53d13e90aab208bf4b8fe4ad957ea949b0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2531,12 +2400,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
-
-[[package]]
-name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
@@ -2548,28 +2411,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -2579,24 +2424,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f91c8b21fbbaa18853c3d0801c78f4fc94cdb976699bb03e832e75f7fd22f0"
-
-[[package]]
-name = "unicode-script"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -3262,24 +3089,6 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
-
-[[package]]
-name = "yazi"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
-
-[[package]]
-name = "zeno"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
 
 [[package]]
 name = "zerocopy"

--- a/examples/wgpu-winit/Cargo.lock
+++ b/examples/wgpu-winit/Cargo.lock
@@ -2150,11 +2150,11 @@ dependencies = [
 name = "sg2d-vega"
 version = "0.1.0"
 dependencies = [
+ "cfg-if",
  "csscolorparser",
  "image",
  "lyon_extra",
  "lyon_path",
- "reqwest",
  "serde",
  "serde_json",
  "sg2d",

--- a/examples/wgpu-winit/Cargo.toml
+++ b/examples/wgpu-winit/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 sg2d-vega = { path = "../../sg2d-vega" }
-sg2d-wgpu = { path = "../../sg2d-wgpu" }
+sg2d-wgpu = { path = "../../sg2d-wgpu", default-features = false }
 sg2d = { path = "../../sg2d" }
 
 cfg-if = "1"

--- a/examples/wgpu-winit/src/util.rs
+++ b/examples/wgpu-winit/src/util.rs
@@ -1,6 +1,6 @@
 use sg2d::scene_graph::SceneGraph;
 use sg2d_vega::scene_graph::VegaSceneGraph;
-use sg2d_wgpu::canvas::{Canvas, WindowCanvas};
+use sg2d_wgpu::canvas::{Canvas, CanvasDimensions, WindowCanvas};
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
@@ -53,7 +53,11 @@ pub async fn run() {
         .expect("Failed to parse scene graph");
 
     // Save to png
-    let mut canvas = WindowCanvas::new(window, scene_graph.width, scene_graph.height, scale)
+    let dimensions = CanvasDimensions {
+        size: [scene_graph.width, scene_graph.height],
+        scale,
+    };
+    let mut canvas = WindowCanvas::new(window, dimensions)
         .await
         .unwrap();
 

--- a/examples/wgpu-winit/src/util.rs
+++ b/examples/wgpu-winit/src/util.rs
@@ -42,7 +42,7 @@ pub async fn run() {
     }
     // Load scene graph
     let scene_spec: VegaSceneGraph = serde_json::from_str(include_str!(
-        "../../../sg2d-vega-test-data/vega-scenegraphs/symbol/binned_scatter_cross_stroke.sg.json"
+        "../../../sg2d-vega-test-data/vega-scenegraphs/gradients/symbol_radial_gradient.sg.json"
     ))
     .unwrap();
 

--- a/sg2d-vega/Cargo.toml
+++ b/sg2d-vega/Cargo.toml
@@ -4,14 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+image-request = ["reqwest"]
 
 [dependencies]
 sg2d = { path = "../sg2d" }
+cfg-if = "1"
 thiserror = { workspace = true }
 serde = { workspace = true }
 csscolorparser = "0.6.2"
 serde_json = { version = "1.0.111" }
 lyon_extra = { workspace = true }
 lyon_path = { workspace = true, features = ["serialization"]}
-reqwest = { version = "0.11.23", features = ["blocking"] }
 image = { workspace = true, default-features = false, features = ["png"] }
+reqwest = { version = "0.11.23", features = ["blocking"], optional = true }

--- a/sg2d-vega/src/error.rs
+++ b/sg2d-vega/src/error.rs
@@ -8,12 +8,22 @@ pub enum VegaSceneGraphError {
     #[error("css color parse error")]
     InvalidColor(#[from] csscolorparser::ParseColorError),
 
+    #[error("image error")]
+    ImageError(#[from] image::ImageError),
+
     // ParseError doesn't implement std::Error, so #[from] doesn't seem to work
     #[error("Error parsing SVG path")]
     InvalidSvgPath(lyon_extra::parser::ParseError),
 
     #[error("Invalid dash string: {0}")]
     InvalidDashString(String),
+
+    #[error("Image fetching is not enabled: {0}")]
+    NoImageFetcherConfigured(String),
+
+    #[cfg(feature = "image-request")]
+    #[error("css color parse error")]
+    ReqwestError(#[from] reqwest::Error),
 }
 
 impl From<lyon_extra::parser::ParseError> for VegaSceneGraphError {

--- a/sg2d-vega/src/image/mod.rs
+++ b/sg2d-vega/src/image/mod.rs
@@ -1,0 +1,24 @@
+#[cfg(feature = "image-request")]
+pub mod reqwest_fetcher;
+
+#[cfg(feature = "image-request")]
+use crate::image::reqwest_fetcher::ReqwestImageFetcher;
+
+use crate::error::VegaSceneGraphError;
+use image::DynamicImage;
+
+pub trait ImageFetcher {
+    fn fetch_image(&self, url: &str) -> Result<DynamicImage, VegaSceneGraphError>;
+}
+
+pub fn make_image_fetcher() -> Result<Box<dyn ImageFetcher>, VegaSceneGraphError> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "image-request")] {
+            Ok(Box::new(ReqwestImageFetcher::new()))
+        } else {
+            Err(VegaSceneGraphError::NoImageFetcherConfigured(
+                "Image fetching requeres the image-reqwest feature flag".to_string()
+            ))
+        }
+    }
+}

--- a/sg2d-vega/src/image/reqwest_fetcher.rs
+++ b/sg2d-vega/src/image/reqwest_fetcher.rs
@@ -1,0 +1,24 @@
+use crate::error::VegaSceneGraphError;
+use crate::image::ImageFetcher;
+use image::DynamicImage;
+use reqwest::blocking::Client;
+
+pub struct ReqwestImageFetcher {
+    client: Client,
+}
+
+impl ReqwestImageFetcher {
+    pub fn new() -> Self {
+        Self {
+            client: Client::new(),
+        }
+    }
+}
+
+impl ImageFetcher for ReqwestImageFetcher {
+    fn fetch_image(&self, url: &str) -> Result<DynamicImage, VegaSceneGraphError> {
+        let img_data = self.client.get(url).send()?.bytes()?.to_vec();
+        let diffuse_image = image::load_from_memory(img_data.as_slice())?;
+        Ok(diffuse_image)
+    }
+}

--- a/sg2d-vega/src/lib.rs
+++ b/sg2d-vega/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod error;
+pub mod image;
 pub mod marks;
 pub mod scene_graph;

--- a/sg2d-vega/src/marks/image.rs
+++ b/sg2d-vega/src/marks/image.rs
@@ -1,6 +1,7 @@
 use crate::error::VegaSceneGraphError;
 use crate::marks::mark::{VegaMarkContainer, VegaMarkItem};
-use reqwest::blocking::Client;
+
+use crate::image::make_image_fetcher;
 use serde::{Deserialize, Serialize};
 use sg2d::marks::image::{ImageMark, RgbaImage};
 use sg2d::marks::mark::SceneMark;
@@ -53,7 +54,8 @@ impl VegaMarkContainer<VegaImageItem> {
         let mut images: Vec<RgbaImage> = Vec::new();
         let mut zindex = Vec::<i32>::new();
 
-        let client = Client::new();
+        // let client = Client::new();
+        let fetcher = make_image_fetcher()?;
 
         for item in &self.items {
             x.push(item.x + origin[0]);
@@ -69,10 +71,7 @@ impl VegaMarkContainer<VegaImageItem> {
                 item.url.clone()
             };
 
-            // TODO: don't panic when loading image and converting to rgba8
-            let img_data = client.get(&url).send().unwrap().bytes().unwrap().to_vec();
-            let diffuse_image = image::load_from_memory(img_data.as_slice()).unwrap();
-
+            let diffuse_image = fetcher.fetch_image(&url)?;
             let rgba_img = diffuse_image.to_rgba8();
             let img_width = rgba_img.width();
             let img_height = rgba_img.height();

--- a/sg2d-wgpu/Cargo.toml
+++ b/sg2d-wgpu/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+text-glyphon = ["glyphon"]
+default = ["text-glyphon"]
+
 [dependencies]
 sg2d = { path = "../sg2d" }
 
@@ -25,7 +29,7 @@ etagere = "0.2.10"
 colorgrad = "0.6.2"
 
 # glyphon branch that includes text rotation support: https://github.com/jonmmease/glyphon/pull/1
-glyphon = { git = "https://github.com/jonmmease/glyphon.git", rev="c468f5dacd4130b27a29b098c4de3f4d5c146209" }
+glyphon = { git = "https://github.com/jonmmease/glyphon.git", rev="c468f5dacd4130b27a29b098c4de3f4d5c146209", optional = true }
 lyon = { workspace = true }
 
 [dev-dependencies]

--- a/sg2d-wgpu/Cargo.toml
+++ b/sg2d-wgpu/Cargo.toml
@@ -29,7 +29,7 @@ glyphon = { git = "https://github.com/jonmmease/glyphon.git", rev="c468f5dacd413
 lyon = { workspace = true }
 
 [dev-dependencies]
-sg2d-vega = { path = "../sg2d-vega" }
+sg2d-vega = { path = "../sg2d-vega", features = ["image-request"] }
 serde_json = { version = "1.0.111" }
 dssim = "3.2.4"
 rstest = "0.18.2"

--- a/sg2d-wgpu/src/error.rs
+++ b/sg2d-wgpu/src/error.rs
@@ -20,4 +20,7 @@ pub enum Sg2dWgpuError {
 
     #[error("Image allocation error: {0}")]
     ImageAllocationError(String),
+
+    #[error("Text support is not enabled: {0}")]
+    TextNotEnabled(String),
 }

--- a/sg2d-wgpu/src/marks/basic_mark.rs
+++ b/sg2d-wgpu/src/marks/basic_mark.rs
@@ -21,6 +21,16 @@ pub trait BasicMarkShader {
     fn vertex_entry_point(&self) -> &str;
     fn fragment_entry_point(&self) -> &str;
     fn vertex_desc(&self) -> wgpu::VertexBufferLayout<'static>;
+
+    fn mag_filter(&self) -> wgpu::FilterMode {
+        wgpu::FilterMode::Nearest
+    }
+    fn min_filter(&self) -> wgpu::FilterMode {
+        wgpu::FilterMode::Nearest
+    }
+    fn mipmap_filter(&self) -> wgpu::FilterMode {
+        wgpu::FilterMode::Nearest
+    }
 }
 
 pub struct BasicMarkRenderer {
@@ -89,23 +99,13 @@ impl BasicMarkRenderer {
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         // Create sampler
-        let linear_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
             address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::FilterMode::Nearest,
-            ..Default::default()
-        });
-
-        let nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Nearest,
-            min_filter: wgpu::FilterMode::Nearest,
-            mipmap_filter: wgpu::FilterMode::Nearest,
+            mag_filter: mark_shader.mag_filter(),
+            min_filter: mark_shader.min_filter(),
+            mipmap_filter: mark_shader.mipmap_filter(),
             ..Default::default()
         });
 
@@ -131,12 +131,6 @@ impl BasicMarkRenderer {
                         ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                        count: None,
-                    },
                 ],
                 label: Some("texture_bind_group_layout"),
             });
@@ -150,11 +144,7 @@ impl BasicMarkRenderer {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::Sampler(&linear_sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::Sampler(&nearest_sampler),
+                    resource: wgpu::BindingResource::Sampler(&sampler),
                 },
             ],
             label: Some("texture_bind_group"),

--- a/sg2d-wgpu/src/marks/gradient.wgsl
+++ b/sg2d-wgpu/src/marks/gradient.wgsl
@@ -12,9 +12,7 @@ const GRADIENT_TEXTURE_HEIGHT = 256.0;
 @group(1) @binding(0)
 var gradient_texture: texture_2d<f32>;
 @group(1) @binding(1)
-var linear_sampler: sampler;
-@group(1) @binding(2)
-var nearest_sampler: sampler;
+var gradient_sampler: sampler;
 
 // Compute final color, potentially computing gradient
 fn lookup_color(color: vec4<f32>, clip_position: vec4<f32>, top_left: vec2<f32>, bottom_right: vec2<f32>) -> vec4<f32> {
@@ -25,11 +23,11 @@ fn lookup_color(color: vec4<f32>, clip_position: vec4<f32>, top_left: vec2<f32>,
         let tex_coord_y = -color[0];
 
         // Extract gradient type from fist pixel using nearest sampler (so that not interpolation is performed)
-        let control0 = textureSample(gradient_texture, nearest_sampler, vec2<f32>(0.0, tex_coord_y));
+        let control0 = textureSample(gradient_texture, gradient_sampler, vec2<f32>(0.0, tex_coord_y));
         let gradient_type = control0[0];
 
         // Extract x/y control points from second pixel
-        let control1 = textureSample(gradient_texture, nearest_sampler, vec2<f32>(1.0 / GRADIENT_TEXTURE_WIDTH, tex_coord_y));
+        let control1 = textureSample(gradient_texture, gradient_sampler, vec2<f32>(1.0 / GRADIENT_TEXTURE_WIDTH, tex_coord_y));
         let x0 = control1[0];
         let y0 = control1[1];
         let x1 = control1[2];
@@ -49,10 +47,10 @@ fn lookup_color(color: vec4<f32>, clip_position: vec4<f32>, top_left: vec2<f32>,
 
             let tex_coord_x = compute_tex_x_coord(projected_dist / control_dist);
 
-            return textureSample(gradient_texture, linear_sampler, vec2<f32>(tex_coord_x, tex_coord_y));
+            return textureSample(gradient_texture, gradient_sampler, vec2<f32>(tex_coord_x, tex_coord_y));
         } else {
            // Extract additional radius gradient control points from third pixel
-            let control2 = textureSample(gradient_texture, nearest_sampler, vec2<f32>(2.0 / GRADIENT_TEXTURE_WIDTH, tex_coord_y));
+            let control2 = textureSample(gradient_texture, gradient_sampler, vec2<f32>(2.0 / GRADIENT_TEXTURE_WIDTH, tex_coord_y));
             let r0 = control2[0];
             let r1 = control2[1];
 
@@ -126,7 +124,7 @@ fn lookup_color(color: vec4<f32>, clip_position: vec4<f32>, top_left: vec2<f32>,
 
             let grad_dist = (frag_radius - r0) / r_delta;
             let tex_coord_x = compute_tex_x_coord(grad_dist);
-            return textureSample(gradient_texture, linear_sampler, vec2<f32>(tex_coord_x, tex_coord_y));
+            return textureSample(gradient_texture, gradient_sampler, vec2<f32>(tex_coord_x, tex_coord_y));
         }
     } else {
         return color;

--- a/sg2d-wgpu/src/marks/image.wgsl
+++ b/sg2d-wgpu/src/marks/image.wgsl
@@ -1,7 +1,7 @@
 struct ChartUniform {
     size: vec2<f32>,
     scale: f32,
-    smooth_: f32,
+    _pad: f32,
 };
 
 @group(0) @binding(0)
@@ -35,15 +35,11 @@ fn vs_main(
 @group(1) @binding(0)
 var texture_atlas: texture_2d<f32>;
 @group(1) @binding(1)
-var linear_sampler: sampler;
+var texture_sampler: sampler;
 @group(1) @binding(2)
 var nearest_sampler: sampler;
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    if (chart_uniforms.smooth_ == 1.0) {
-        return textureSample(texture_atlas, linear_sampler, in.tex_coords);
-    } else {
-        return textureSample(texture_atlas, nearest_sampler, in.tex_coords);
-    }
+    return textureSample(texture_atlas, texture_sampler, in.tex_coords);
 }

--- a/sg2d-wgpu/src/marks/instanced_mark.rs
+++ b/sg2d-wgpu/src/marks/instanced_mark.rs
@@ -25,6 +25,16 @@ pub trait InstancedMarkShader {
     fn fragment_entry_point(&self) -> &str;
     fn instance_desc(&self) -> wgpu::VertexBufferLayout<'static>;
     fn vertex_desc(&self) -> wgpu::VertexBufferLayout<'static>;
+
+    fn mag_filter(&self) -> wgpu::FilterMode {
+        wgpu::FilterMode::Nearest
+    }
+    fn min_filter(&self) -> wgpu::FilterMode {
+        wgpu::FilterMode::Nearest
+    }
+    fn mipmap_filter(&self) -> wgpu::FilterMode {
+        wgpu::FilterMode::Nearest
+    }
 }
 
 pub struct InstancedMarkRenderer {
@@ -96,23 +106,13 @@ impl InstancedMarkRenderer {
         let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         // Create sampler
-        let linear_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             address_mode_u: wgpu::AddressMode::ClampToEdge,
             address_mode_v: wgpu::AddressMode::ClampToEdge,
             address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::FilterMode::Nearest,
-            ..Default::default()
-        });
-
-        let nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Nearest,
-            min_filter: wgpu::FilterMode::Nearest,
-            mipmap_filter: wgpu::FilterMode::Nearest,
+            mag_filter: mark_shader.mag_filter(),
+            min_filter: mark_shader.min_filter(),
+            mipmap_filter: mark_shader.mipmap_filter(),
             ..Default::default()
         });
 
@@ -138,12 +138,6 @@ impl InstancedMarkRenderer {
                         ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                         count: None,
                     },
-                    wgpu::BindGroupLayoutEntry {
-                        binding: 2,
-                        visibility: wgpu::ShaderStages::FRAGMENT,
-                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                        count: None,
-                    },
                 ],
                 label: Some("texture_bind_group_layout"),
             });
@@ -157,11 +151,7 @@ impl InstancedMarkRenderer {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::Sampler(&linear_sampler),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::Sampler(&nearest_sampler),
+                    resource: wgpu::BindingResource::Sampler(&sampler),
                 },
             ],
             label: Some("texture_bind_group"),

--- a/sg2d-wgpu/src/marks/mod.rs
+++ b/sg2d-wgpu/src/marks/mod.rs
@@ -7,4 +7,6 @@ pub mod path;
 pub mod rect;
 pub mod rule;
 pub mod symbol;
+
+#[cfg(feature = "text-glyphon")]
 pub mod text;


### PR DESCRIPTION
Fixes the wasm build and examples.

Makes image and text mark support optional. Reverts to using a single sampler per mark to fix wgpu/webgl error