### PR TITLE
Run tests on GitHub Actions with macos runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "check-linux"
       - name: Check cargo fmt compliance
         run: cargo fmt --all -- --check
       - name: Check no rustc warnings
@@ -43,9 +45,18 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
+      - name: Install latest stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - uses: Swatinem/rust-cache@v2
-      - name: Run tests
-        run: cd sg2d-wgpu && cargo test --verbose -- --nocapture
+        with:
+          prefix-key: "test-macos"
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: test --verbose -- --nocapture
       - name: Update images
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
       - name: Check cargo fmt compliance
         run: cargo fmt --all -- --check
       - name: Check no rustc warnings
@@ -50,8 +51,14 @@ jobs:
 #        run: cargo clippy
 #      - name: Build
 #        run: cargo build --verbose
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --verbose
+        run: cd sg2d-wgpu && cargo test --verbose -- --nocapture
+      - name: Update images
+        uses: actions/upload-artifact@v4
+        with:
+          name: images-win
+          path: sg2d-wgpu/tests/output
 
   test-rs-macos:
     runs-on: macos-latest
@@ -71,5 +78,11 @@ jobs:
 #        run: cargo clippy
 #      - name: Build
 #        run: cargo build --verbose
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --verbose
+        run: cd sg2d-wgpu && cargo test --verbose -- --nocapture
+      - name: Update images
+        uses: actions/upload-artifact@v4
+        with:
+          name: images-macos
+          path: sg2d-wgpu/tests/output

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,3 +31,41 @@ jobs:
 #  # Tests currently fail with `MakeWgpuAdapterError`
 #      - name: Run tests
 #        run: cargo test --verbose
+
+  test-rs-win:
+    runs-on: windows-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Check cargo fmt compliance
+        run: cargo fmt --all -- --check
+      - name: Check no rustc warnings
+        run: cargo check --tests
+      - name: Check for clippy warnings
+        run: cargo clippy
+      - name: Build
+        run: cargo build --verbose
+
+  test-rs-macos:
+    runs-on: macos-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Check cargo fmt compliance
+        run: cargo fmt --all -- --check
+      - name: Check no rustc warnings
+        run: cargo check --tests
+      - name: Check for clippy warnings
+        run: cargo clippy
+      - name: Build
+        run: cargo build --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,15 +48,15 @@ jobs:
       - name: Install latest stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.74.1
           override: true
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "test-macos"
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: test --verbose -- --nocapture
+      - name: version
+        run: rustc --version
+      - name: test
+        run:  cd sg2d-wgpu/ && cargo test -- --nocapture
       - name: Update images
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,33 +33,6 @@ jobs:
 #      - name: Run tests
 #        run: cargo test --verbose
 
-  test-rs-win:
-    runs-on: windows-latest
-    env:
-      RUSTFLAGS: "-D warnings"
-    steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v3
-#      - name: Check cargo fmt compliance
-#        run: cargo fmt --all -- --check
-#      - name: Check no rustc warnings
-#        run: cargo check --tests
-#      - name: Check for clippy warnings
-#        run: cargo clippy
-#      - name: Build
-#        run: cargo build --verbose
-      - uses: Swatinem/rust-cache@v2
-      - name: Run tests
-        run: cd sg2d-wgpu && cargo test --verbose -- --nocapture
-      - name: Update images
-        uses: actions/upload-artifact@v4
-        with:
-          name: images-win
-          path: sg2d-wgpu/tests/output
-
   test-rs-macos:
     runs-on: macos-latest
     env:
@@ -70,14 +43,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
-#      - name: Check cargo fmt compliance
-#        run: cargo fmt --all -- --check
-#      - name: Check no rustc warnings
-#        run: cargo check --tests
-#      - name: Check for clippy warnings
-#        run: cargo clippy
-#      - name: Build
-#        run: cargo build --verbose
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cd sg2d-wgpu && cargo test --verbose -- --nocapture

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,14 +42,16 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
-      - name: Check cargo fmt compliance
-        run: cargo fmt --all -- --check
-      - name: Check no rustc warnings
-        run: cargo check --tests
-      - name: Check for clippy warnings
-        run: cargo clippy
-      - name: Build
-        run: cargo build --verbose
+#      - name: Check cargo fmt compliance
+#        run: cargo fmt --all -- --check
+#      - name: Check no rustc warnings
+#        run: cargo check --tests
+#      - name: Check for clippy warnings
+#        run: cargo clippy
+#      - name: Build
+#        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
 
   test-rs-macos:
     runs-on: macos-latest
@@ -61,11 +63,13 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
-      - name: Check cargo fmt compliance
-        run: cargo fmt --all -- --check
-      - name: Check no rustc warnings
-        run: cargo check --tests
-      - name: Check for clippy warnings
-        run: cargo clippy
-      - name: Build
-        run: cargo build --verbose
+#      - name: Check cargo fmt compliance
+#        run: cargo fmt --all -- --check
+#      - name: Check no rustc warnings
+#        run: cargo check --tests
+#      - name: Check for clippy warnings
+#        run: cargo clippy
+#      - name: Build
+#        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install latest stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.74.1
+          toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
The macos GitHub Actions runner is the only one that works with wgpu out of the box (using the metal backend I believe). We'll need to work out how to test windows and linux eventually, but this at least gives us some testing against baselines in CI.